### PR TITLE
Hotfix .Net version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:1.1-sdk-projectjson
+FROM microsoft/dotnet:2.0.5-sdk-2.1.4-jessie
 
 RUN mkdir -p /openchain
 


### PR DESCRIPTION
Update Dockerfile to 2.0.5 version of .Net Framework and 2.1.4 version of CLT